### PR TITLE
default db_schema to 'public'

### DIFF
--- a/feast_postgres/offline_stores/postgres.py
+++ b/feast_postgres/offline_stores/postgres.py
@@ -45,7 +45,6 @@ class PostgreSQLOfflineStoreConfig(PostgreSQLConfig):
     type: Literal[
         "feast_postgres.PostgreSQLOfflineStore"
     ] = "feast_postgres.PostgreSQLOfflineStore"
-    db_schema: StrictStr
 
 
 class PostgreSQLOfflineStore(OfflineStore):

--- a/feast_postgres/postgres_config.py
+++ b/feast_postgres/postgres_config.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from pydantic import StrictStr
 
 from feast.repo_config import FeastConfigBaseModel
@@ -9,6 +7,6 @@ class PostgreSQLConfig(FeastConfigBaseModel):
     host: StrictStr
     port: int = 5432
     database: StrictStr
-    db_schema: Optional[StrictStr] = None
+    db_schema: StrictStr = "public"
     user: StrictStr
     password: StrictStr


### PR DESCRIPTION
[As stated on Postgres's website](https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PUBLIC), the default schema name is `"public"`.

> In the previous sections we created tables without specifying any schema names. By default such tables (and other objects) are automatically put into a schema named “public”. 

